### PR TITLE
chore(package): move sb/api into sb/manager-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@storybook/addons": "^7.0.0",
-    "@storybook/api": "^7.0.0",
+    "@storybook/manager-api": "^7.0.0",
     "@storybook/components": "^7.0.0",
     "@storybook/core-events": "^7.0.0",
     "@storybook/global": "^5.0.0",


### PR DESCRIPTION
Hello,

As mentionned in the readme, the "api" package was moved ("renamed") into "manager-api": [https://www.npmjs.com/package/@storybook/api](https://www.npmjs.com/package/@storybook/api)